### PR TITLE
fix: [GATE] remove certs from ipsec module

### DIFF
--- a/scripts/chef_vpn_gate/vpn-gate/cookbooks/ipsec2/resources/setup_ipsec.rb
+++ b/scripts/chef_vpn_gate/vpn-gate/cookbooks/ipsec2/resources/setup_ipsec.rb
@@ -17,38 +17,9 @@ action :setup do
   end
 
   if app_name == "ipsec"
-    remote_file '/etc/ssl/certs/isrgrootx1.pem' do
-        source 'https://letsencrypt.org/certs/isrgrootx1.pem'
-        action :create
-    end
-
-    remote_file '/etc/ssl/certs/isrg-root-x1-cross-signed.pem' do
-        source 'https://letsencrypt.org/certs/isrg-root-x1-cross-signed.pem'
-        action :create
-    end
-
-    remote_file '/etc/ssl/certs/isrg-root-x2.pem' do
-        source 'https://letsencrypt.org/certs/isrg-root-x2.pem'
-        action :create
-    end
-
-    remote_file '/etc/ssl/certs/isrg-root-x2-cross-signed.pem' do
-        source 'https://letsencrypt.org/certs/isrg-root-x2-cross-signed.pem'
-        action :create
-    end
 
     remote_file '/etc/ssl/certs/lets-encrypt-r3.pem' do
         source 'https://letsencrypt.org/certs/lets-encrypt-r3.pem'
-        action :create
-    end
-
-    remote_file '/etc/ssl/certs/lets-encrypt-r3-cross-signed.pem' do
-        source 'https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem'
-        action :create
-    end
-
-    remote_file '/etc/ssl/certs/lets-encrypt-e1.pem' do
-        source 'https://letsencrypt.org/certs/lets-encrypt-e1.pem'
         action :create
     end
 

--- a/scripts/chef_vpn_gate/vpn-gate/cookbooks/ipsec2/resources/setup_ipsec.rb
+++ b/scripts/chef_vpn_gate/vpn-gate/cookbooks/ipsec2/resources/setup_ipsec.rb
@@ -17,9 +17,28 @@ action :setup do
   end
 
   if app_name == "ipsec"
+    remote_file '/etc/ssl/certs/isrgrootx1.pem' do
+        source 'https://letsencrypt.org/certs/isrgrootx1.pem'
+        action :create
+    end
+
+    remote_file '/etc/ssl/certs/isrg-root-x2.pem' do
+        source 'https://letsencrypt.org/certs/isrg-root-x2.pem'
+        action :create
+    end
+
+    remote_file '/etc/ssl/certs/isrg-root-x2-cross-signed.pem' do
+        source 'https://letsencrypt.org/certs/isrg-root-x2-cross-signed.pem'
+        action :create
+    end
 
     remote_file '/etc/ssl/certs/lets-encrypt-r3.pem' do
         source 'https://letsencrypt.org/certs/lets-encrypt-r3.pem'
+        action :create
+    end
+
+    remote_file '/etc/ssl/certs/lets-encrypt-e1.pem' do
+        source 'https://letsencrypt.org/certs/lets-encrypt-e1.pem'
         action :create
     end
 


### PR DESCRIPTION
remove certs which are not needed to avoid certificates conflict with the existing default certs.